### PR TITLE
Lecture #15

### DIFF
--- a/wp-content/themes/aquila/README.md
+++ b/wp-content/themes/aquila/README.md
@@ -118,3 +118,18 @@
               * Here just creating a combination of trait and singelton
               
               * Check after http://advpress.example.com/wp-content/themes/aquila/my-php/index.php
+
+
+# Lecture 15 - Singelton design in wordpress
+              * Create /srv/www/advance_wordpress/wordpress/wp-content/themes/aquila/inc/headers
+              * In that add autoloader.php
+              * you can just look github repo to find the auto loader
+
+              * Create /srv/www/advance_wordpress/wordpress/wp-content/themes/aquila/inc/traits/trait-singelton.php
+              * Here we use Autoloader that help to include all class automatically, we dont need to worry of that
+              * use 
+                ** echo '<pre>';
+                   print_r(AQUILA_DIR_PATH);
+                   ap_die;
+
+                ** which help to find, upto which dir its loading    

--- a/wp-content/themes/aquila/functions.php
+++ b/wp-content/themes/aquila/functions.php
@@ -5,16 +5,11 @@
  * @package Aquila
  */
 
-// echo '<pre>';
-// print_r(get_stylesheet_uri());
-// wp_die();
 
-
-// Used for time stamp (newest version of theme can Identified using the time stamp);
-// We can see the timestamp changing when ever the we done any updation on styles.
-// echo '<pre>';
-// print_r(filemtime(get_template_directory() . '/style.css'));
-// wp_die();
+if (!defined('AQUILA_DIR_PATH')){
+    define('AQUILA_DIR_PATH', untrailingslashit(get_template_directory_uri()));
+}
+require_once AQUILA_DIR_PATH . '/inc/helper/autoloader.php';
 
 
 function aquila_enqueue_scripts()

--- a/wp-content/themes/aquila/inc/headers/autoloader.php
+++ b/wp-content/themes/aquila/inc/headers/autoloader.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Autoloader file for theme.
+ *
+ * @package Aquila
+ */
+
+namespace AQUILA_THEME\Inc\Helpers;
+
+/**
+ * Auto loader function.
+ *
+ * @param string $resource Source namespace.
+ *
+ * @return void
+ */
+function autoloader( $resource = '' ) {
+	$resource_path  = false;
+	$namespace_root = 'AQUILA_THEME\\';
+	$resource       = trim( $resource, '\\' );
+
+	if ( empty( $resource ) || strpos( $resource, '\\' ) === false || strpos( $resource, $namespace_root ) !== 0 ) {
+		// Not our namespace, bail out.
+		return;
+	}
+
+	// Remove our root namespace.
+	$resource = str_replace( $namespace_root, '', $resource );
+
+	$path = explode(
+		'\\',
+		str_replace( '_', '-', strtolower( $resource ) )
+	);
+
+	/**
+	 * Time to determine which type of resource path it is,
+	 * so that we can deduce the correct file path for it.
+	 */
+	if ( empty( $path[0] ) || empty( $path[1] ) ) {
+		return;
+	}
+
+	$directory = '';
+	$file_name = '';
+
+	if ( 'inc' === $path[0] ) {
+
+		switch ( $path[1] ) {
+			case 'traits':
+				$directory = 'traits';
+				$file_name = sprintf( 'trait-%s', trim( strtolower( $path[2] ) ) );
+				break;
+
+			case 'widgets':
+			case 'blocks': // phpcs:ignore PSR2.ControlStructures.SwitchDeclaration.TerminatingComment
+				/**
+				 * If there is class name provided for specific directory then load that.
+				 * otherwise find in inc/ directory.
+				 */
+				if ( ! empty( $path[2] ) ) {
+					$directory = sprintf( 'classes/%s', $path[1] );
+					$file_name = sprintf( 'class-%s', trim( strtolower( $path[2] ) ) );
+					break;
+				}
+			default:
+				$directory = 'classes';
+				$file_name = sprintf( 'class-%s', trim( strtolower( $path[1] ) ) );
+				break;
+		}
+
+		$resource_path = sprintf( '%s/inc/%s/%s.php', untrailingslashit( AQUILA_DIR_PATH ), $directory, $file_name );
+
+	}
+
+	/**
+	 * If $is_valid_file has 0 means valid path or 2 means the file path contains a Windows drive path.
+	 */
+	$is_valid_file = validate_file( $resource_path );
+
+	if ( ! empty( $resource_path ) && file_exists( $resource_path ) && ( 0 === $is_valid_file || 2 === $is_valid_file ) ) {
+		// We already making sure that file is exists and valid.
+		require_once( $resource_path ); // phpcs:ignore
+	}
+
+}
+
+spl_autoload_register( '\AQUILA_THEME\Inc\Helpers\autoloader' );

--- a/wp-content/themes/aquila/inc/traits/trait-singelton.php
+++ b/wp-content/themes/aquila/inc/traits/trait-singelton.php
@@ -1,0 +1,26 @@
+<?php 
+
+namespace aquila\inc\traits;
+
+
+trait Singeleton {
+    public function __construct() {
+
+    }
+    public function __clone() {
+
+    }
+    final public static function get_instance() {
+        static $instance = [ ]; 
+
+        $called_class = get_called_class();
+
+        if( !isset($instance[$called_class])){
+            $instance[$called_class] = new $called_class(); 
+
+            do_action (sprintf('aquila_theme_singelton_init%s', $called_class));
+        }
+
+        return $instance['$called_class'];
+    }
+}


### PR DESCRIPTION
# Lecture 15 - Singelton design in wordpress
              * Create /srv/www/advance_wordpress/wordpress/wp-content/themes/aquila/inc/headers
              * In that add autoloader.php
              * you can just look github repo to find the auto loader

              * Create /srv/www/advance_wordpress/wordpress/wp-content/themes/aquila/inc/traits/trait-singelton.php
              * Here we use Autoloader that help to include all class automatically, we dont need to worry of that
              * use 
                ** echo '<pre>';
                   print_r(AQUILA_DIR_PATH);
                   ap_die;

                ** which help to find, upto which dir its loading    