### PR TITLE
 Lecture #17

### DIFF
--- a/wp-content/themes/aquila/README.md
+++ b/wp-content/themes/aquila/README.md
@@ -285,3 +285,25 @@ echo $teacher::class;  // Outputs: "Teacher"
               * Since here we are using singleton function we doest want to instantiate the function it will automatically instantiate( if you have ny doubt or for further understand go to previous topics).
               * The path has been included. /srv/www/advance_wordpress/wordpress/wp-content/themes/aquila/lectures/lecture-16.png
               * Mainly oops concept is used wordpress to make the functions.php make clean. which help to create large projects and make easy to edit , and help to find where to edit.
+
+# Lecture 17 - Enqueue with OOP.
+              * Here declaring constant
+              if (!defined('AQUILA_DIR_PATH')){
+                  define('AQUILA_DIR_PATH', untrailingslashit(get_template_directory()));
+               }
+               if (!defined('AQUILA_DIR_URI')){
+                  define('AQUILA_DIR_URI', untrailingslashit(get_template_directory_uri()));
+               }
+
+               is used that we can change AQUIL_DIR_URI or PATH instead of get_template_uri() or get_template_dir()
+               for eg: 
+                 ** wp_register_style('style-css', get_stylesheet_uri(), [], filemtime(get_template_directory() . '/style.css'), 'all');
+                 this can be change to 
+                 ** wp_register_style('style-css', get_stylesheet_uri(), [], filemtime(AQUILA_DIR_PATH . '/style.css'), 'all');
+                    wp_register_style('bootstrap-css', AQUILA_DIR_URI . '/assets/src/library/css/bootstrap.min.css', [], false, 'all');
+
+             * Create a file /srv/www/advance_wordpress/wordpress/wp-content/themes/aquila/inc/classes/class-assets.php
+             just for separate the enqueue script to Assets- so the functions.php will clean
+             * As we know that autoload will automatically call the classes that are present
+           *  
+ 

--- a/wp-content/themes/aquila/functions.php
+++ b/wp-content/themes/aquila/functions.php
@@ -11,6 +11,10 @@
 if (!defined('AQUILA_DIR_PATH')){
     define('AQUILA_DIR_PATH', untrailingslashit(get_template_directory()));
 }
+if (!defined('AQUILA_DIR_URI')){
+    define('AQUILA_DIR_URI', untrailingslashit(get_template_directory_uri()));
+}
+
 
 // Require the autoloader file.
 require_once AQUILA_DIR_PATH . '/inc/helpers/autoloader.php';
@@ -25,20 +29,5 @@ aquila_get_theme_instance();
 
 function aquila_enqueue_scripts()
 {   
-    // Register Styles
-    wp_register_style('style-css', get_stylesheet_uri(), [], filemtime(get_template_directory() . '/style.css'), 'all');
-    wp_register_style('bootstrap-css', get_template_directory_uri() . '/assets/src/library/css/bootstrap.min.css', [], false, 'all');
 
-    // Register Scripts 
-    wp_register_script('main-js', get_template_directory_uri() . '/assets/main.js', [], filemtime(get_template_directory() . '/assets/main.js'), true);
-    wp_register_script('bootstrap-js', get_template_directory_uri() . '/assets/src/library/js/bootstrap.min.js', ['jquery'], false, true);
-
-    // Enqueue Styles
-    wp_enqueue_style('style-css');
-    wp_enqueue_style('bootstrap-css');
-
-    // Enqueue Scripts 
-    wp_enqueue_script('main-js');
-    wp_enqueue_script('bootstrap-js');
 }
-add_action('wp_enqueue_scripts', 'aquila_enqueue_scripts');

--- a/wp-content/themes/aquila/inc/classes/class-aquila-theme.php
+++ b/wp-content/themes/aquila/inc/classes/class-aquila-theme.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Bootstrap the theme
  * 
@@ -9,19 +9,28 @@ namespace AQUILA_THEME\Inc;
 
 use AQUILA_THEME\Inc\Traits\Singleton;
 
-class AQUILA_THEME {
+class AQUILA_THEME
+{
     use Singleton;
 
     // Constructor
-    protected function __construct() {
+    protected function __construct()
+    {
         // wp_die("Hello");
-        // Load Class
-        $this->set_hooks();
+        // Load Class.
+
+        Assets::get_instance();
+        $this->setup_hooks();
     }
- 
-  
+
+
     //  Its protected bcz I don't want any other classes to access it  
-     protected function set_hooks(){
-        // Actions and Filter 
-     }
- }
+    protected function setup_hooks()
+    {
+        
+     
+
+    }
+
+
+}

--- a/wp-content/themes/aquila/inc/classes/class-assets.php
+++ b/wp-content/themes/aquila/inc/classes/class-assets.php
@@ -1,0 +1,65 @@
+<?php 
+/**
+ * Enqueue Theme assets
+ * 
+ * @package Aquila
+ * 
+ */
+namespace AQUILA_THEME\Inc;
+
+use AQUILA_THEME\Inc\Traits\Singleton;
+
+class Assets{
+    use Singleton;
+
+
+        // Constructor
+        protected function __construct()
+        {
+            // wp_die("Hello");
+            // Load Class
+            $this->setup_hooks();
+        }
+    
+    
+        //  Its protected bcz I don't want any other classes to access it  
+        protected function setup_hooks()
+        {
+            /**
+             * Actions
+             */  
+            add_action('wp_enqueue_scripts', [$this, 'register_styles']);
+            add_action('wp_enqueue_scripts', [$this, 'register_scripts']);
+    
+        }
+    
+        public function register_styles()
+        {
+            // Register Styles
+            wp_register_style('style-css', get_stylesheet_uri(), [], filemtime(AQUILA_DIR_PATH . '/style.css'), 'all');
+            wp_register_style('bootstrap-css', AQUILA_DIR_URI . '/assets/src/library/css/bootstrap.min.css', [], false, 'all');
+    
+    
+            // Enqueue Styles
+            wp_enqueue_style('style-css');
+            wp_enqueue_style('bootstrap-css');
+    
+        }
+        public function register_scripts()
+        {
+    
+            // Register Scripts 
+            wp_register_script('main-js', AQUILA_DIR_URI . '/assets/main.js', [], filemtime(AQUILA_DIR_PATH . '/assets/main.js'), true);
+            wp_register_script('bootstrap-js', AQUILA_DIR_URI . '/assets/src/library/js/bootstrap.min.js', ['jquery'], false, true);
+    
+    
+            // Enqueue Scripts 
+            wp_enqueue_script('main-js');
+            wp_enqueue_script('bootstrap-js');
+    
+    
+        }
+    
+    }
+
+

--- a/wp-content/themes/aquila/inc/helpers/autoloader.php
+++ b/wp-content/themes/aquila/inc/helpers/autoloader.php
@@ -41,9 +41,7 @@ function autoloader( $resource = '' ) {
 	}
 
 
-	echo '<pre>';
-	print_r($path);
-	wp_die();
+
 
 	$directory = '';
 	$file_name = '';


### PR DESCRIPTION
* Here declaring constant
              if (!defined('AQUILA_DIR_PATH')){
                  define('AQUILA_DIR_PATH', untrailingslashit(get_template_directory()));
               }
               if (!defined('AQUILA_DIR_URI')){
                  define('AQUILA_DIR_URI', untrailingslashit(get_template_directory_uri()));
               }

               is used that we can change AQUIL_DIR_URI or PATH instead of get_template_uri() or get_template_dir()
               for eg: 
                 ** wp_register_style('style-css', get_stylesheet_uri(), [], filemtime(get_template_directory() . '/style.css'), 'all');
                 this can be change to 
                 ** wp_register_style('style-css', get_stylesheet_uri(), [], filemtime(AQUILA_DIR_PATH . '/style.css'), 'all');
                    wp_register_style('bootstrap-css', AQUILA_DIR_URI . '/assets/src/library/css/bootstrap.min.css', [], false, 'all');

             * Create a file /srv/www/advance_wordpress/wordpress/wp-content/themes/aquila/inc/classes/class-assets.php
             just for separate the enqueue script to Assets- so the functions.php will clean
             * As we know that autoload will automatically call the classes that are present