### PR TITLE
 Lecture #22

### DIFF
--- a/wp-content/themes/aquila/README.md
+++ b/wp-content/themes/aquila/README.md
@@ -333,4 +333,30 @@ echo $teacher::class;  // Outputs: "Teacher"
              * It is used to add featured-image option on the pages
              * In this lecture mostly covered different theme_supports and its functionalities more are to be covered just check on google
              * You can just go through class-aquila-theme.php and parallely check the dashboard before and after adding theme support, so you can understand where the new options are present.
-             *                  
+                               
+# Lecture 22 - Registering Nav Menu
+             * Create a new class called class-menus.php 
+             * For translation purposes we use translation functions such as esc_html_e
+             * so here we change the 
+                 ** register_nav_menus([
+                     'aquila-header-menu' => __('Header Menu'),
+                     'aquila-footer-menu' => __('Footer Menu'),
+         
+                   ]);
+
+                   -----(to)---------
+
+                 ** register_nav_menus([
+                     'aquila-header-menu' => esc_html__('Header Menu','aquila'),
+                     'aquila-footer-menu' => esc_html__('Footer Menu','aquila'),
+         
+                   ]); 
+             
+             * Just check the menus have been registered or not in dashboard>appearance>menus.
+             *  So just create some pages on dashboard and register the menus by going to dashboard>appearance>menus and create a menu, link it with which menu type you want.whether to footer menu or header menu (as your need).
+             *  After assigning the next work is to done on front-end : that is displaying the registed menu  on the locations that you want
+             *  for that we use wp_nav_menu(array(...)) on the template_part>nav .
+             * When ever we create nav menu the wordpress will create a bunch of classes around the navmenu just inspect or view page source code
+             * To solve that issue there are several methods
+             * one of the advance way is using the Nav Walker class.
+             * There is other method it will be covered in the coming lectures.    

--- a/wp-content/themes/aquila/inc/classes/class-aquila-theme.php
+++ b/wp-content/themes/aquila/inc/classes/class-aquila-theme.php
@@ -20,6 +20,9 @@ class AQUILA_THEME
         // Load Class.
 
         Assets::get_instance();
+
+        Menus::get_instance();
+        
         $this->setup_hooks();
     }
 
@@ -90,7 +93,7 @@ class AQUILA_THEME
 
         // Set the global content width for media elements
         global $content_width;
-        if (!isset($content_width)) {
+        if ( !isset($content_width)) {
             $content_width = 1240; // Maximum content width in pixels
         }
 

--- a/wp-content/themes/aquila/inc/classes/class-menus.php
+++ b/wp-content/themes/aquila/inc/classes/class-menus.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * 
+ * Registering Nav Menus.
+ * 
+ * @package Aquila
+ * 
+ */
+
+ namespace AQUILA_THEME\Inc;
+
+ use AQUILA_THEME\Inc\Traits\Singleton;
+
+
+ class Menus{
+    use Singleton;
+
+     // Constructor
+     protected function __construct()
+     {
+         // wp_die("Hello");
+         // Load Class
+         $this->setup_hooks();
+     }
+ 
+ 
+     //  Its protected bcz I don't want any other classes to access it  
+     protected function setup_hooks()
+     {
+         /**
+          * Actions
+          */  
+         add_action('init', [$this, 'register_menus']);
+ 
+     }
+
+     public function register_menus(){
+
+        register_nav_menus([
+            'aquila-header-menu' => esc_html__('Header Menu','aquila'),
+            'aquila-footer-menu' => esc_html__('Footer Menu','aquila'),
+
+        ]);
+     }
+ 
+     
+ 
+ 
+ }

--- a/wp-content/themes/aquila/template-parts/header/nav.php
+++ b/wp-content/themes/aquila/template-parts/header/nav.php
@@ -49,3 +49,13 @@
     </div>
   </div>
 </nav>
+
+
+<?php 
+  wp_nav_menu(
+    [
+      'theme_location' => 'aquila-header-menu',
+      'container_class' => 'my_extra_menu_class'
+    ]
+  )
+ ?>


### PR DESCRIPTION
* Create a new class called class-menus.php 
             * For translation purposes we use translation functions such as esc_html_e
             * so here we change the 
                 ** register_nav_menus([
                     'aquila-header-menu' => __('Header Menu'),
                     'aquila-footer-menu' => __('Footer Menu'),
         
                   ]);

                   -----(to)---------

                 ** register_nav_menus([
                     'aquila-header-menu' => esc_html__('Header Menu','aquila'),
                     'aquila-footer-menu' => esc_html__('Footer Menu','aquila'),
         
                   ]); 
             
             * Just check the menus have been registered or not in dashboard>appearance>menus.
             *  So just create some pages on dashboard and register the menus by going to dashboard>appearance>menus and create a menu, link it with which menu type you want.whether to footer menu or header menu (as your need).
             *  After assigning the next work is to done on front-end : that is displaying the registed menu  on the locations that you want
             *  for that we use wp_nav_menu(array(...)) on the template_part>nav .
             * When ever we create nav menu the wordpress will create a bunch of classes around the navmenu just inspect or view page source code
             * To solve that issue there are several methods
             * one of the advance way is using the Nav Walker class.
             * There is other method it will be covered in the coming lectures. 